### PR TITLE
[ISSUE 227] Solve unhandled NetworkException issue

### DIFF
--- a/leku/src/main/java/com/schibstedspain/leku/geocoder/GoogleGeocoderDataSource.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/geocoder/GoogleGeocoderDataSource.kt
@@ -4,6 +4,7 @@ import android.location.Address
 import com.google.android.gms.maps.model.LatLng
 import com.schibstedspain.leku.geocoder.api.AddressBuilder
 import com.schibstedspain.leku.geocoder.api.NetworkClient
+import com.schibstedspain.leku.geocoder.api.NetworkException
 import io.reactivex.Observable
 import java.util.Locale
 import org.json.JSONException
@@ -39,6 +40,8 @@ class GoogleGeocoderDataSource(
                 subscriber.onComplete()
             } catch (e: JSONException) {
                 subscriber.onError(e)
+            } catch (e: NetworkException) {
+                subscriber.onError(e)
             }
         }
     }
@@ -59,6 +62,8 @@ class GoogleGeocoderDataSource(
                 subscriber.onComplete()
             } catch (e: JSONException) {
                 subscriber.onError(e)
+            } catch (e: NetworkException) {
+                subscriber.onError(e)
             }
         }
     }
@@ -77,6 +82,8 @@ class GoogleGeocoderDataSource(
                 }
                 subscriber.onComplete()
             } catch (e: JSONException) {
+                subscriber.onError(e)
+            } catch (e: NetworkException) {
                 subscriber.onError(e)
             }
         }


### PR DESCRIPTION
## ISSUE
[#227](https://github.com/AdevintaSpain/Leku/issues/277)

## Description
NetworkException was not handled correctly:

> Fatal Exception: io.reactivex.exceptions.UndeliverableException
> The exception could not be delivered to the consumer because it has already canceled/disposed the flow or the exception has nowhere to go to begin with. Further reading: https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling | HTTP error code: 400

## Screenshots
No screens

## Mandatory GIF
![mandatory](https://media.giphy.com/media/JtwMddKpsF9Hq/giphy.gif)