### PR TITLE
Remove the last RxJava2 dependency

### DIFF
--- a/leku/build.gradle
+++ b/leku/build.gradle
@@ -96,10 +96,6 @@ dependencies {
 
   implementation 'io.reactivex.rxjava3:rxjava:3.0.3'
   implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
-  implementation 'com.github.akarnokd:rxjava3-bridge:3.0.0'
-  implementation('io.reactivex.rxjava2:rxjava:2.2.19') {
-    because("pl.charmas.android:android-reactive-location needs it")
-  }
   implementation 'nl.littlerobots.rxlint:rxlint:1.7.4'
 
 

--- a/leku/build.gradle
+++ b/leku/build.gradle
@@ -39,6 +39,9 @@ android {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
   }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
+  }
   dexOptions {
     preDexLibraries "true" != System.getenv("TRAVIS")
   }

--- a/leku/build.gradle
+++ b/leku/build.gradle
@@ -94,8 +94,6 @@ dependencies {
 
   implementation "com.google.maps:google-maps-services:0.2.9"
 
-  implementation 'com.github.MarsXan:Android-ReactiveLocation:2.1.0'
-
   implementation 'io.reactivex.rxjava3:rxjava:3.0.3'
   implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
   implementation 'com.github.akarnokd:rxjava3-bridge:3.0.0'

--- a/leku/lib-proguard-rules.txt
+++ b/leku/lib-proguard-rules.txt
@@ -19,11 +19,6 @@
 # Retrolambda
 -dontwarn java.lang.invoke.*
 
-# Reactive Location Provider 2
--dontwarn pl.charmas.android.reactivelocation2.**
--keep interface pl.charmas.android.reactivelocation2.** { *; }
--keep class pl.charmas.android.reactivelocation2.** { *; }
-
 # Google Maps
 -keep class com.google.maps.** { *; }
 -dontwarn com.google.maps.**

--- a/leku/src/main/java/com/schibstedspain/leku/LocationPickerActivity.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/LocationPickerActivity.kt
@@ -72,11 +72,9 @@ import com.schibstedspain.leku.locale.DefaultCountryLocaleRect
 import com.schibstedspain.leku.locale.SearchZoneRect
 import com.schibstedspain.leku.permissions.PermissionUtils
 import com.schibstedspain.leku.tracker.TrackEvents
-import pl.charmas.android.reactivelocation2.ReactiveLocationProvider
-import java.util.TimeZone
+import com.schibstedspain.leku.utils.ReactiveLocationProvider
 import java.util.Locale
-import kotlin.collections.ArrayList
-import kotlin.collections.HashMap
+import java.util.TimeZone
 import kotlin.collections.set
 
 const val LATITUDE = "latitude"

--- a/leku/src/main/java/com/schibstedspain/leku/geocoder/GeocoderPresenter.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/geocoder/GeocoderPresenter.kt
@@ -7,7 +7,6 @@ import com.google.android.gms.maps.model.LatLngBounds
 import com.schibstedspain.leku.geocoder.places.GooglePlacesDataSource
 import com.schibstedspain.leku.geocoder.timezone.GoogleTimeZoneDataSource
 import com.schibstedspain.leku.utils.ReactiveLocationProvider
-import hu.akarnokd.rxjava3.bridge.RxJavaBridge
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.ObservableSource
@@ -50,7 +49,7 @@ class GeocoderPresenter @JvmOverloads constructor(
 
     fun getLastKnownLocation() {
         @SuppressLint("MissingPermission")
-        val disposable = RxJavaBridge.toV3Single(locationProvider.getLastKnownLocation())
+        val disposable = locationProvider.getLastKnownLocation()
                 .retry(RETRY_COUNT.toLong())
                 .subscribe({ view?.showLastLocation(it) },
                         { view?.didGetLastLocation() })

--- a/leku/src/main/java/com/schibstedspain/leku/geocoder/GeocoderPresenter.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/geocoder/GeocoderPresenter.kt
@@ -6,20 +6,18 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.schibstedspain.leku.geocoder.places.GooglePlacesDataSource
 import com.schibstedspain.leku.geocoder.timezone.GoogleTimeZoneDataSource
+import com.schibstedspain.leku.utils.ReactiveLocationProvider
 import hu.akarnokd.rxjava3.bridge.RxJavaBridge
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.ObservableSource
 import io.reactivex.rxjava3.core.Scheduler
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.functions.BiFunction
 import io.reactivex.rxjava3.schedulers.Schedulers
-import pl.charmas.android.reactivelocation2.ReactiveLocationProvider
 import java.util.concurrent.TimeUnit
 import java.util.TimeZone
 import kotlin.collections.ArrayList
-import kotlin.collections.List
-import kotlin.collections.isNotEmpty
 
 private const val RETRY_COUNT = 3
 private const val MAX_PLACES_RESULTS = 3
@@ -52,7 +50,7 @@ class GeocoderPresenter @JvmOverloads constructor(
 
     fun getLastKnownLocation() {
         @SuppressLint("MissingPermission")
-        val disposable = RxJavaBridge.toV3Single(locationProvider.lastKnownLocation)
+        val disposable = RxJavaBridge.toV3Single(locationProvider.getLastKnownLocation())
                 .retry(RETRY_COUNT.toLong())
                 .subscribe({ view?.showLastLocation(it) },
                         { view?.didGetLastLocation() })

--- a/leku/src/main/java/com/schibstedspain/leku/utils/BaseLocationObservableOnSubscribe.java
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/BaseLocationObservableOnSubscribe.java
@@ -6,7 +6,7 @@ import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 
-import io.reactivex.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableEmitter;
 
 public abstract class BaseLocationObservableOnSubscribe<T> extends BaseObservableOnSubscribe<T> {
 

--- a/leku/src/main/java/com/schibstedspain/leku/utils/BaseLocationObservableOnSubscribe.java
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/BaseLocationObservableOnSubscribe.java
@@ -1,0 +1,24 @@
+package com.schibstedspain.leku.utils;
+
+import android.content.Context;
+
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationServices;
+
+import io.reactivex.ObservableEmitter;
+
+public abstract class BaseLocationObservableOnSubscribe<T> extends BaseObservableOnSubscribe<T> {
+
+    protected BaseLocationObservableOnSubscribe(Context ctx) {
+        super(ctx, LocationServices.API);
+    }
+
+    @Override
+    protected final void onGoogleApiClientReady(Context context, GoogleApiClient googleApiClient, ObservableEmitter<? super T> emitter) {
+        onLocationProviderClientReady(LocationServices.getFusedLocationProviderClient(context), emitter);
+    }
+
+    protected abstract void onLocationProviderClientReady(FusedLocationProviderClient locationProviderClient,
+                                                          ObservableEmitter<? super T> emitter);
+}

--- a/leku/src/main/java/com/schibstedspain/leku/utils/BaseObservableOnSubscribe.java
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/BaseObservableOnSubscribe.java
@@ -1,0 +1,116 @@
+package com.schibstedspain.leku.utils;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.api.Api;
+import com.google.android.gms.common.api.GoogleApiClient;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.reactivex.ObservableEmitter;
+import io.reactivex.ObservableOnSubscribe;
+import io.reactivex.disposables.Disposables;
+import io.reactivex.functions.Action;
+
+public abstract class BaseObservableOnSubscribe<T> implements ObservableOnSubscribe<T> {
+    private final Context ctx;
+    private final List<Api<? extends Api.ApiOptions.NotRequiredOptions>> services;
+
+    @SafeVarargs
+    protected BaseObservableOnSubscribe(Context ctx, Api<? extends Api.ApiOptions.NotRequiredOptions>... services) {
+        this.ctx = ctx;
+        this.services = Arrays.asList(services);
+    }
+
+    @Override
+    public void subscribe(ObservableEmitter<T> emitter) throws Exception {
+        final GoogleApiClient apiClient = createApiClient(emitter);
+        try {
+            apiClient.connect();
+        } catch (Throwable ex) {
+            if (!emitter.isDisposed()) {
+                emitter.onError(ex);
+            }
+        }
+
+        emitter.setDisposable(Disposables.fromAction(new Action() {
+            @Override
+            public void run() throws Exception {
+                onDisposed();
+                apiClient.disconnect();
+            }
+        }));
+    }
+
+    private GoogleApiClient createApiClient(ObservableEmitter<? super T> emitter) {
+        ApiClientConnectionCallbacks apiClientConnectionCallbacks = new ApiClientConnectionCallbacks(ctx, emitter);
+        GoogleApiClient.Builder apiClientBuilder = new GoogleApiClient.Builder(ctx);
+
+        for (Api<? extends Api.ApiOptions.NotRequiredOptions> service : services) {
+            apiClientBuilder = apiClientBuilder.addApi(service);
+        }
+
+        apiClientBuilder = apiClientBuilder
+                .addConnectionCallbacks(apiClientConnectionCallbacks)
+                .addOnConnectionFailedListener(apiClientConnectionCallbacks);
+
+        GoogleApiClient apiClient = apiClientBuilder.build();
+        apiClientConnectionCallbacks.setClient(apiClient);
+        return apiClient;
+    }
+
+    protected void onDisposed() {
+    }
+
+    protected abstract void onGoogleApiClientReady(Context context, GoogleApiClient googleApiClient, ObservableEmitter<? super T> emitter);
+
+    private class ApiClientConnectionCallbacks implements
+            GoogleApiClient.ConnectionCallbacks,
+            GoogleApiClient.OnConnectionFailedListener {
+
+        final private Context context;
+
+        final private ObservableEmitter<? super T> emitter;
+
+        private GoogleApiClient apiClient;
+
+        private ApiClientConnectionCallbacks(Context context, ObservableEmitter<? super T> emitter) {
+            this.context = context;
+            this.emitter = emitter;
+        }
+
+        @Override
+        public void onConnected(Bundle bundle) {
+            try {
+                onGoogleApiClientReady(context, apiClient, emitter);
+            } catch (Throwable ex) {
+                if (!emitter.isDisposed()) {
+                    emitter.onError(ex);
+                }
+            }
+        }
+
+        @Override
+        public void onConnectionSuspended(int cause) {
+            if (!emitter.isDisposed()) {
+                emitter.onError(new IllegalStateException());
+            }
+        }
+
+        @Override
+        public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
+            if (!emitter.isDisposed()) {
+                emitter.onError(new IllegalStateException("Error connecting to GoogleApiClient"));
+            }
+        }
+
+        void setClient(GoogleApiClient client) {
+            this.apiClient = client;
+        }
+    }
+}

--- a/leku/src/main/java/com/schibstedspain/leku/utils/BaseObservableOnSubscribe.java
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/BaseObservableOnSubscribe.java
@@ -12,10 +12,10 @@ import com.google.android.gms.common.api.GoogleApiClient;
 import java.util.Arrays;
 import java.util.List;
 
-import io.reactivex.ObservableEmitter;
-import io.reactivex.ObservableOnSubscribe;
-import io.reactivex.disposables.Disposables;
-import io.reactivex.functions.Action;
+import io.reactivex.rxjava3.core.ObservableEmitter;
+import io.reactivex.rxjava3.core.ObservableOnSubscribe;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.functions.Action;
 
 public abstract class BaseObservableOnSubscribe<T> implements ObservableOnSubscribe<T> {
     private final Context ctx;
@@ -38,7 +38,7 @@ public abstract class BaseObservableOnSubscribe<T> implements ObservableOnSubscr
             }
         }
 
-        emitter.setDisposable(Disposables.fromAction(new Action() {
+        emitter.setDisposable(Disposable.fromAction(new Action() {
             @Override
             public void run() throws Exception {
                 onDisposed();

--- a/leku/src/main/java/com/schibstedspain/leku/utils/LastKnownLocationObservableOnSubscribe.java
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/LastKnownLocationObservableOnSubscribe.java
@@ -1,0 +1,57 @@
+package com.schibstedspain.leku.utils;
+
+import android.content.Context;
+import android.location.Location;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+
+import io.reactivex.Observable;
+import io.reactivex.ObservableEmitter;
+
+public class LastKnownLocationObservableOnSubscribe extends BaseLocationObservableOnSubscribe<Location> {
+
+    public static Observable<Location> createObservable(Context ctx) {
+        return Observable.create(new LastKnownLocationObservableOnSubscribe(ctx));
+    }
+
+    private LastKnownLocationObservableOnSubscribe(Context ctx) {
+        super(ctx);
+    }
+
+    @Override
+    protected void onLocationProviderClientReady(FusedLocationProviderClient locationProviderClient,
+                                                 final ObservableEmitter<? super Location> emitter) {
+        locationProviderClient.getLastLocation()
+                .addOnSuccessListener(new OnSuccessListener<Location>() {
+                    @Override
+                    public void onSuccess(Location location) {
+                        if (emitter.isDisposed()) return;
+                        if (location != null) {
+                            emitter.onNext(location);
+                        }
+                        emitter.onComplete();
+                    }
+                })
+                .addOnFailureListener(new BaseFailureListener<>(emitter));
+    }
+
+    public static class BaseFailureListener<T> implements OnFailureListener {
+
+        private final ObservableEmitter<? super T> emitter;
+
+        public BaseFailureListener(ObservableEmitter<? super T> emitter) {
+            this.emitter = emitter;
+        }
+
+        @Override
+        public void onFailure(@NonNull Exception exception) {
+            if (emitter.isDisposed()) return;
+            emitter.onError(exception);
+            emitter.onComplete();
+        }
+    }
+}

--- a/leku/src/main/java/com/schibstedspain/leku/utils/LastKnownLocationObservableOnSubscribe.java
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/LastKnownLocationObservableOnSubscribe.java
@@ -9,8 +9,8 @@ import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 
-import io.reactivex.Observable;
-import io.reactivex.ObservableEmitter;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.ObservableEmitter;
 
 public class LastKnownLocationObservableOnSubscribe extends BaseLocationObservableOnSubscribe<Location> {
 

--- a/leku/src/main/java/com/schibstedspain/leku/utils/ReactiveLocationProvider.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/ReactiveLocationProvider.kt
@@ -1,0 +1,14 @@
+package com.schibstedspain.leku.utils
+
+import android.content.Context
+import android.location.Location
+import androidx.annotation.RequiresPermission
+import io.reactivex.Single
+
+class ReactiveLocationProvider(val context: Context) {
+
+    @RequiresPermission(anyOf = ["android.permission.ACCESS_COARSE_LOCATION", "android.permission.ACCESS_FINE_LOCATION"])
+    fun getLastKnownLocation(): Single<Location> {
+        return LastKnownLocationObservableOnSubscribe.createObservable(context).singleOrError()
+    }
+}

--- a/leku/src/main/java/com/schibstedspain/leku/utils/ReactiveLocationProvider.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/utils/ReactiveLocationProvider.kt
@@ -3,7 +3,7 @@ package com.schibstedspain.leku.utils
 import android.content.Context
 import android.location.Location
 import androidx.annotation.RequiresPermission
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Single
 
 class ReactiveLocationProvider(val context: Context) {
 


### PR DESCRIPTION
`com.github.MarsXan:Android-ReactiveLocation` doesn't get updates since 3 years ago. It depends on android support and it depends on RxJava2. For that reason I'm removing that dependency.

Luckly we were using only one little feature from it so I just copied the necessary code to the project to keep it working.

Then I moved the code to RxJava3 so I removed our dependency with RxJava2 too.