### PR TITLE
Disable jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx2048m
 org.gradle.configureondemand=false
 android.useAndroidX=true
-android.enableJetifier=true

--- a/leku/build.gradle
+++ b/leku/build.gradle
@@ -102,14 +102,14 @@ dependencies {
   implementation 'nl.littlerobots.rxlint:rxlint:1.7.4'
 
 
-  def espressoVersion = '3.1.0-alpha4'
+  def espressoVersion = '3.1.0'
   androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
   androidTestImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
 
-  def supportTestVersion = '1.1.0-alpha4'
+  def supportTestVersion = '1.1.0'
   androidTestImplementation "androidx.test:runner:$supportTestVersion"
   androidTestImplementation "androidx.test:rules:$supportTestVersion"
-  androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
+  androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
   androidTestImplementation 'org.mockito:mockito-core:2.28.2'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"


### PR DESCRIPTION
Depends on #301 

Now that we removed Android-ReactiveLocation we don't have any dependency using to the old android support. So we can disable jetifier 🎉. Happy faster builds (no fast, just faster. Remeber we are still using Android 😛)