### PR TITLE
Handle exception thrown by TimeZoneApi when getting timezone without api-key

### DIFF
--- a/leku/src/main/java/com/adevinta/leku/geocoder/timezone/GoogleTimeZoneDataSource.kt
+++ b/leku/src/main/java/com/adevinta/leku/geocoder/timezone/GoogleTimeZoneDataSource.kt
@@ -7,6 +7,7 @@ import com.google.maps.TimeZoneApi
 import com.google.maps.errors.ApiException
 import com.google.maps.model.LatLng
 import java.io.IOException
+import java.lang.IllegalStateException
 import java.util.TimeZone
 
 class GoogleTimeZoneDataSource(private val geoApiContext: GeoApiContext) {
@@ -32,6 +33,7 @@ class GoogleTimeZoneDataSource(private val geoApiContext: GeoApiContext) {
         } catch (ignored: ApiException) {
         } catch (ignored: InterruptedException) {
         } catch (ignored: IOException) {
+        } catch (ignored: IllegalStateException) {
         }
         return null
     }


### PR DESCRIPTION
## ISSUE
Maybe related to #308 

## Description
Clicking on the map launches two calls, from `GeocoderPresenter.getInfoFromLocation(LatLng)`:
1. Geocoder from LatLng
2. Get Timezone
 
If no ApiKey is provided to work with the TimeZone API, an IllegalStateException is thrown, causing the `getInfoFromLocation` to fail and the address obtained from the Geocoder call is not painted in the address box.

## Screenshots
Before | After
---|---
<img width="280" src="https://user-images.githubusercontent.com/17499757/149134904-9dc919de-5f0a-48e2-83c2-d112b763f1f4.png" /> | <img width="280" src="https://user-images.githubusercontent.com/17499757/149134914-c96631a5-23a8-4056-a616-853189e8c25f.png" />

## Mandatory GIF
![mandatory](https://c.tenor.com/vvktIE0tx9kAAAAd/into-the-map-joe-tribbiani.gif)