### PR TITLE
Show complete addressLine in search list

### DIFF
--- a/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
+++ b/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
@@ -1259,18 +1259,21 @@ class LocationPickerActivity : AppCompatActivity(),
     }
 
     private fun getFullAddressString(address: Address): String {
-        var fullAddress = ""
-        address.featureName?.let {
-            fullAddress += it
-        }
-        if (address.subLocality != null && address.subLocality.isNotEmpty()) {
-            fullAddress += ", " + address.subLocality
-        }
-        if (address.locality != null && address.locality.isNotEmpty()) {
-            fullAddress += ", " + address.locality
-        }
-        if (address.countryName != null && address.countryName.isNotEmpty()) {
-            fullAddress += ", " + address.countryName
+        var fullAddress = address.getAddressLine(0)
+        if (fullAddress.isNullOrEmpty()) {
+            fullAddress = ""
+            address.featureName?.let {
+                fullAddress += it
+            }
+            if (address.subLocality != null && address.subLocality.isNotEmpty()) {
+                fullAddress += ", " + address.subLocality
+            }
+            if (address.locality != null && address.locality.isNotEmpty()) {
+                fullAddress += ", " + address.locality
+            }
+            if (address.countryName != null && address.countryName.isNotEmpty()) {
+                fullAddress += ", " + address.countryName
+            }
         }
         return fullAddress
     }


### PR DESCRIPTION
## ISSUE
No issue

## Description
Depending on how the user types the address they want to search for, the addresses displayed in the results list are not readable.
The `Address` object already has an` addressLine` property that contains the full human readable address.
In this PR I'm using this property, if it has a value. If not, the full address is built as before.

## Screenshots
Before | After
---|---
<img width="280" src="https://user-images.githubusercontent.com/17499757/149137490-07dee83f-7f61-400b-a12e-bb8da2f4ce32.png" /> | <img width="280" src="https://user-images.githubusercontent.com/17499757/149137504-3080eeab-9a2e-42a1-bf70-b44d3057cba9.png" />

## Mandatory GIF
![mandatory](https://media.giphy.com/media/1Fuk0EbGP7JbG/giphy.gif)