### PR TITLE
Reduce geocoder calls and UI updates when searching

### DIFF
--- a/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
+++ b/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
@@ -76,6 +76,7 @@ import com.adevinta.leku.utils.ReactiveLocationProvider
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.ObservableEmitter
+import io.reactivex.rxjava3.disposables.CompositeDisposable
 import java.util.Locale
 import java.util.TimeZone
 import java.util.concurrent.TimeUnit
@@ -185,6 +186,7 @@ class LocationPickerActivity : AppCompatActivity(),
     private var isSearchLayoutShown = false
     private lateinit var toolbar: MaterialToolbar
     private lateinit var timeZone: TimeZone
+    private val compositeDisposable = CompositeDisposable()
 
     private val defaultZoom: Int
         get() {
@@ -417,12 +419,12 @@ class LocationPickerActivity : AppCompatActivity(),
       val searchTextChangeObservable = createSearchViewTextChangeObservable()
       val disposable = searchTextChangeObservable
         .observeOn(AndroidSchedulers.mainThread())
-        .doOnNext { willLoadLocation() }
         .subscribe({ term ->
           onSearchTextChanged(term)
         }, {
           // onError just do nothing, do not execute search
         })
+      compositeDisposable.add(disposable)
     }
 
     private fun onSearchTextChanged(term: String) {
@@ -610,6 +612,7 @@ class LocationPickerActivity : AppCompatActivity(),
             searchView?.removeTextChangedListener(it)
         }
         googleApiClient?.unregisterConnectionCallbacks(this)
+        compositeDisposable.dispose()
         super.onDestroy()
     }
 

--- a/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
+++ b/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
@@ -385,70 +385,70 @@ class LocationPickerActivity : AppCompatActivity(),
     }
 
     private fun setUpSearchView() {
-      searchView = findViewById(R.id.leku_search)
-      searchView?.setOnEditorActionListener { v, actionId, _ ->
-        var handled = false
-        if (actionId == EditorInfo.IME_ACTION_SEARCH && v.text.toString().isNotEmpty()) {
-          retrieveLocationFrom(v.text.toString())
-          closeKeyboard()
-          handled = true
+        searchView = findViewById(R.id.leku_search)
+        searchView?.setOnEditorActionListener { v, actionId, _ ->
+            var handled = false
+            if (actionId == EditorInfo.IME_ACTION_SEARCH && v.text.toString().isNotEmpty()) {
+                retrieveLocationFrom(v.text.toString())
+                closeKeyboard()
+                handled = true
+            }
+            handled
         }
-        handled
-      }
-      createSearchTextChangeObserver()
-      if (!isLegacyLayoutEnabled) {
-        searchView?.setOnFocusChangeListener { _: View?, hasFocus: Boolean ->
-          if (hasFocus) {
-            showSearchLayout()
-          }
+        createSearchTextChangeObserver()
+        if (!isLegacyLayoutEnabled) {
+            searchView?.setOnFocusChangeListener { _: View?, hasFocus: Boolean ->
+                if (hasFocus) {
+                    showSearchLayout()
+                }
+            }
         }
-      }
     }
 
     private fun createSearchViewTextChangeObservable(): Observable<String> = Observable.create { subscriber: ObservableEmitter<String> ->
-      searchView?.addTextChangedListener(object : TextWatcher {
-        override fun afterTextChanged(s: Editable) {}
-        override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
-        override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
-          subscriber.onNext(s.toString())
-        }
-      })
+        searchView?.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(s: Editable) {}
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+                subscriber.onNext(s.toString())
+            }
+        })
     }.debounce(DEBOUNCE_TIME.toLong(), TimeUnit.MILLISECONDS, AndroidSchedulers.mainThread())
 
     private fun createSearchTextChangeObserver() {
-      val searchTextChangeObservable = createSearchViewTextChangeObservable()
-      val disposable = searchTextChangeObservable
-        .observeOn(AndroidSchedulers.mainThread())
-        .subscribe({ term ->
-          onSearchTextChanged(term)
-        }, {
-          // onError just do nothing, do not execute search
-        })
-      compositeDisposable.add(disposable)
+        val searchTextChangeObservable = createSearchViewTextChangeObservable()
+        val disposable = searchTextChangeObservable
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ term ->
+                    onSearchTextChanged(term)
+                }, {
+                    // onError just do nothing, do not execute search
+                })
+        compositeDisposable.add(disposable)
     }
 
     private fun onSearchTextChanged(term: String) {
-      if (term.isEmpty()) {
-        if (isLegacyLayoutEnabled) {
-          adapter?.let {
-            it.clear()
-            it.notifyDataSetChanged()
-          }
+        if (term.isEmpty()) {
+            if (isLegacyLayoutEnabled) {
+                adapter?.let {
+                    it.clear()
+                    it.notifyDataSetChanged()
+                }
+            } else {
+                searchAdapter?.notifyDataSetChanged()
+            }
+            showLocationInfoLayout()
+            clearSearchButton?.visibility = View.INVISIBLE
+            searchOption?.setIcon(R.drawable.leku_ic_mic_legacy)
+            updateVoiceSearchVisibility()
         } else {
-          searchAdapter?.notifyDataSetChanged()
+            if (term.length > MIN_CHARACTERS) {
+                retrieveLocationWithDebounceTimeFrom(term)
+            }
+            clearSearchButton?.visibility = View.VISIBLE
+            searchOption?.setIcon(R.drawable.leku_ic_search)
+            searchOption?.isVisible = true
         }
-        showLocationInfoLayout()
-        clearSearchButton?.visibility = View.INVISIBLE
-        searchOption?.setIcon(R.drawable.leku_ic_mic_legacy)
-        updateVoiceSearchVisibility()
-      } else {
-        if (term.length > MIN_CHARACTERS) {
-          retrieveLocationWithDebounceTimeFrom(term)
-        }
-        clearSearchButton?.visibility = View.VISIBLE
-        searchOption?.setIcon(R.drawable.leku_ic_search)
-        searchOption?.isVisible = true
-      }
     }
 
     private fun showSearchLayout() {


### PR DESCRIPTION
## ISSUE
No related issue

## Description
When searching, the current implementation is making too many requests to the geocoder, with the corresponding update of the results list, one for each request. You can see the effect in the first columns of screenshots.

To improve the UX in this part, my idea is to rethink the debounce implementation, applying it to the `onTextChangeListener`. This way the request itself will be done only after `DEBOUNCE_TIME` milliseconds has passed without changing the term of search.

## Screenshots
Before | After
---|---
<img width="280" src="https://user-images.githubusercontent.com/17499757/151790142-f9087cc9-b490-46ef-8ad5-be1236069b9d.gif" /> | <img width="280" src="https://user-images.githubusercontent.com/17499757/151790164-4d4d895d-0aa4-44a9-ba6f-1453e497d75c.gif" />
<img width="280" src="https://user-images.githubusercontent.com/17499757/151784406-b2ab8925-fe32-4ec4-9d1a-6f01ab25569d.gif" /> | <img width="280" src="https://user-images.githubusercontent.com/17499757/151784421-a2efbc10-5098-47ab-a125-b4274518748b.gif" />

## Mandatory GIF
![mandatory](https://media.giphy.com/media/14aLuWEyopPrFK/giphy.gif)