### PR TITLE
fix: force null custom adapter and data source to avoid memory leak

### DIFF
--- a/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
+++ b/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
@@ -680,6 +680,8 @@ class LocationPickerActivity :
             searchView?.removeTextChangedListener(it)
         }
         googleApiClient?.unregisterConnectionCallbacks(this)
+        customDataSource = null
+        customAdapter = null
         super.onDestroy()
     }
 


### PR DESCRIPTION
## ISSUE
Memory leak with custom adapter and custom data source due to its static behaviour

## Description
Force null dependencies on activity destroy to avoid memory leaks.

## Screenshots
Before | After
---|---
<img width="280" src="" /> | <img width="280" src="" />

## Mandatory GIF
![mandatory](https://media.giphy.com/media/148T2DGwOmtG6h5Jap/giphy-downsized-large.gif)