### PR TITLE
Fix: Reiterated results not found toast

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx2048m
 org.gradle.configureondemand=false
 android.useAndroidX=true
 libGroup=com.adevinta.android
-libVersion=10.0.2
+libVersion=10.0.3

--- a/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
+++ b/leku/src/main/java/com/adevinta/leku/LocationPickerActivity.kt
@@ -170,6 +170,8 @@ class LocationPickerActivity :
     private var clearLocationButton: ImageButton? = null
     private var searchEditLayout: LinearLayout? = null
     private var searchFrameLayout: FrameLayout? = null
+    private var suggestionsToast: Toast? = null
+    private var locationsToast: Toast? = null
 
     private val locationList = ArrayList<Address>()
     private val suggestionList = ArrayList<PlaceSuggestion>()
@@ -810,11 +812,15 @@ class LocationPickerActivity :
         changeListResultVisibility(View.GONE)
     }
 
+    private fun makeEmptyResultsToast(): Toast =
+        Toast.makeText(applicationContext, R.string.leku_no_search_results, Toast.LENGTH_LONG)
+
     override fun showLocations(addresses: List<Address>) {
         fillLocationList(addresses)
         if (addresses.isEmpty()) {
-            Toast.makeText(applicationContext, R.string.leku_no_search_results, Toast.LENGTH_LONG)
-                .show()
+            locationsToast?.cancel()
+            locationsToast = makeEmptyResultsToast()
+            locationsToast!!.show()
         } else {
             updateLocationNameList(addresses)
             if (hasWiderZoom) {
@@ -834,8 +840,9 @@ class LocationPickerActivity :
     override fun showSuggestions(suggestions: List<PlaceSuggestion>) {
         fillSuggestionList(suggestions)
         if (suggestions.isEmpty()) {
-            Toast.makeText(applicationContext, R.string.leku_no_search_results, Toast.LENGTH_LONG)
-                .show()
+            suggestionsToast?.cancel()
+            suggestionsToast = makeEmptyResultsToast()
+            suggestionsToast!!.show()
         } else {
             updateSuggestionNameList(suggestions)
             if (hasWiderZoom) {


### PR DESCRIPTION
## ISSUE

## Description
On searches the snack bar with message "not found results" is appearing all the time. Appears when results list is showing info, or when we close the screen or the app.

## Screenshots
Before | After
---|---
<img width="280" src="" /> | <img width="280" src="" />

## Mandatory GIF
![mandatory](https://media.giphy.com/media/1Fuk0EbGP7JbG/giphy.gif)